### PR TITLE
When clicking the menu

### DIFF
--- a/docs/using-ormconfig.md
+++ b/docs/using-ormconfig.md
@@ -96,7 +96,7 @@ TYPEORM_DATABASE = test
 TYPEORM_PORT = 3000
 TYPEORM_SYNCHRONIZE = true
 TYPEORM_LOGGING = true
-TYPEORM_ENTITIES = entity/.*js,modules/**/entity/.*js
+TYPEORM_ENTITIES = entity/*.js,modules/**/entity/*.js
 ```
 
 List of available env variables you can set:


### PR DESCRIPTION
Typo in .env configuration: .*js changed to *.js