### PR TITLE
Choose two branches to see what’s

### DIFF
--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -635,7 +635,7 @@ export class OracleDriver implements Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string {
-        return ":" + parameterName;
+        return ":" + (index + 1);
     }
 
     /**

--- a/test/github-issues/5067/issue-5067.ts
+++ b/test/github-issues/5067/issue-5067.ts
@@ -1,0 +1,20 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {Connection} from "../../../src";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+
+describe("github issues > #5067 ORA-00972: identifier is too long", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        enabledDrivers: ["oracle"]
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("generated parameter name is within the size constraints", () => Promise.all(connections.map(async connection => {
+        const paramName = "output_that_is_really_long_and_must_be_truncated_in_this_driver";
+        const createdParameter = await connection.driver.createParameter(paramName, 0);
+
+        expect(createdParameter).to.be.an("String");
+        expect(createdParameter.length).to.be.lessThan(30);
+    })));
+});


### PR DESCRIPTION
* fix: resolve issues ora-00972:identifier is too long

Closes: #5067

* fix: ensure that this changes applies just for Oracle Driver

Closes: #5067

* fix test - remove `.only` & set the `enabledDrivers` to oracle

* simplify test case

Co-authored-by: Murat Gundes <guendes.murat@indivumed.com>